### PR TITLE
Fix invalid allowNull parameter in shipment DTO

### DIFF
--- a/src/DTO/Shipment.php
+++ b/src/DTO/Shipment.php
@@ -28,7 +28,7 @@ class Shipment
     #[Assert\Length(min: 2, max: 2)]
     public string $country;
 
-    #[Assert\Email(allowNull: true)]
+    #[Assert\Email]
     public ?string $email;
 
     #[Assert\NotBlank(allowNull: true)]

--- a/tests/DTO/ShipmentValidationTest.php
+++ b/tests/DTO/ShipmentValidationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Sendcloud\Bundle\Tests\DTO;
+
+use PHPUnit\Framework\TestCase;
+use Sendcloud\Bundle\DTO\Shipment;
+use Symfony\Component\Validator\Validation;
+
+class ShipmentValidationTest extends TestCase
+{
+    public function testValidationAllowsNullOptionalFields(): void
+    {
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $shipment = new Shipment(
+            'John Doe',
+            null,
+            'Main Street',
+            '42',
+            '12345',
+            'Metropolis',
+            'NL',
+            null,
+            null,
+            1.0
+        );
+
+        $violations = $validator->validate($shipment);
+
+        self::assertCount(0, $violations);
+    }
+}


### PR DESCRIPTION
## Summary
- remove unsupported `allowNull` parameter from email constraint
- add test ensuring validation works with null optional fields

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_b_689de0a4aec8832daba62369b3178217