### PR TITLE
Replace shipment weight with parcels and ship_with

### DIFF
--- a/src/DTO/Parcel.php
+++ b/src/DTO/Parcel.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Sendcloud\Bundle\DTO;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class Parcel
+{
+    #[Assert\Positive]
+    public float $weight;
+
+    public function __construct(float $weight)
+    {
+        $this->weight = $weight;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'weight' => $this->weight,
+        ];
+    }
+}

--- a/src/DTO/Shipment.php
+++ b/src/DTO/Shipment.php
@@ -12,14 +12,27 @@ class Shipment
     #[Assert\Valid]
     public Address $fromAddress;
 
-    #[Assert\Positive]
-    public float $weight;
+    /**
+     * @var Parcel[]
+     */
+    #[Assert\Valid]
+    public array $parcels;
 
-    public function __construct(Address $toAddress, Address $fromAddress, float $weight)
+    /**
+     * @var array{type:string}
+     */
+    public array $shipWith;
+
+    /**
+     * @param Parcel[] $parcels
+     * @param array{type:string} $shipWith
+     */
+    public function __construct(Address $toAddress, Address $fromAddress, array $parcels, array $shipWith = ['type' => 'sendcloud:letter'])
     {
         $this->toAddress = $toAddress;
         $this->fromAddress = $fromAddress;
-        $this->weight = $weight;
+        $this->parcels = $parcels;
+        $this->shipWith = $shipWith;
     }
 
     public function toArray(): array
@@ -27,7 +40,8 @@ class Shipment
         return [
             'to_address' => $this->toAddress->toArray(),
             'from_address' => $this->fromAddress->toArray(),
-            'weight' => $this->weight,
+            'parcels' => array_map(static fn(Parcel $parcel) => $parcel->toArray(), $this->parcels),
+            'ship_with' => $this->shipWith,
         ];
     }
 }

--- a/src/Entity/ShipmentEntityInterface.php
+++ b/src/Entity/ShipmentEntityInterface.php
@@ -3,10 +3,18 @@
 namespace Sendcloud\Bundle\Entity;
 
 use Sendcloud\Bundle\DTO\Address;
+use Sendcloud\Bundle\DTO\Parcel;
 
 interface ShipmentEntityInterface
 {
     public function getToAddress(): Address;
     public function getFromAddress(): Address;
-    public function getWeight(): float;
+    /**
+     * @return Parcel[]
+     */
+    public function getParcels(): array;
+    /**
+     * @return array{type:string}
+     */
+    public function getShipWith(): array;
 }

--- a/src/Factory/ShipmentDtoFactory.php
+++ b/src/Factory/ShipmentDtoFactory.php
@@ -12,7 +12,8 @@ class ShipmentDtoFactory
         return new Shipment(
             $entity->getToAddress(),
             $entity->getFromAddress(),
-            $entity->getWeight(),
+            $entity->getParcels(),
+            $entity->getShipWith(),
         );
     }
 }

--- a/tests/DTO/ShipmentTest.php
+++ b/tests/DTO/ShipmentTest.php
@@ -5,6 +5,7 @@ namespace Sendcloud\Bundle\Tests\DTO;
 use PHPUnit\Framework\TestCase;
 use Sendcloud\Bundle\DTO\Address;
 use Sendcloud\Bundle\DTO\Shipment;
+use Sendcloud\Bundle\DTO\Parcel;
 
 class ShipmentTest extends TestCase
 {
@@ -34,12 +35,16 @@ class ShipmentTest extends TestCase
             null
         );
 
-        $shipment = new Shipment($to, $from, 1.5);
+        $parcel = new Parcel(1.5);
+        $shipment = new Shipment($to, $from, [$parcel]);
 
         $expected = [
             'to_address' => $to->toArray(),
             'from_address' => $from->toArray(),
-            'weight' => 1.5,
+            'parcels' => [
+                ['weight' => 1.5],
+            ],
+            'ship_with' => ['type' => 'sendcloud:letter'],
         ];
 
         self::assertSame($expected, $shipment->toArray());

--- a/tests/DTO/ShipmentValidationTest.php
+++ b/tests/DTO/ShipmentValidationTest.php
@@ -5,6 +5,7 @@ namespace Sendcloud\Bundle\Tests\DTO;
 use PHPUnit\Framework\TestCase;
 use Sendcloud\Bundle\DTO\Address;
 use Sendcloud\Bundle\DTO\Shipment;
+use Sendcloud\Bundle\DTO\Parcel;
 use Symfony\Component\Validator\Validation;
 
 class ShipmentValidationTest extends TestCase
@@ -34,7 +35,8 @@ class ShipmentValidationTest extends TestCase
             null,
             null,
         );
-        $shipment = new Shipment($to, $from, 1.0);
+        $parcel = new Parcel(1.0);
+        $shipment = new Shipment($to, $from, [$parcel]);
 
         $violations = $validator->validate($shipment);
 

--- a/tests/Factory/ShipmentDtoFactoryTest.php
+++ b/tests/Factory/ShipmentDtoFactoryTest.php
@@ -5,6 +5,7 @@ namespace Sendcloud\Bundle\Tests\Factory;
 use PHPUnit\Framework\TestCase;
 use Sendcloud\Bundle\DTO\Address;
 use Sendcloud\Bundle\DTO\Shipment;
+use Sendcloud\Bundle\DTO\Parcel;
 use Sendcloud\Bundle\Entity\ShipmentEntityInterface;
 use Sendcloud\Bundle\Factory\ShipmentDtoFactory;
 
@@ -19,7 +20,8 @@ class ShipmentDtoFactoryTest extends TestCase
             public function getFromAddress(): Address {
                 return new Address('Sender', null, 'Main Street', '1', '12345', 'Metropolis', 'NL', null, '+31612345678');
             }
-            public function getWeight(): float { return 2.0; }
+            public function getParcels(): array { return [new Parcel(2.0)]; }
+            public function getShipWith(): array { return ['type' => 'sendcloud:letter']; }
         };
 
         $factory = new ShipmentDtoFactory();
@@ -28,6 +30,7 @@ class ShipmentDtoFactoryTest extends TestCase
         self::assertInstanceOf(Shipment::class, $shipment);
         self::assertSame('Jane Doe', $shipment->toAddress->name);
         self::assertSame('Sender', $shipment->fromAddress->name);
-        self::assertSame(2.0, $shipment->weight);
+        self::assertSame(2.0, $shipment->parcels[0]->weight);
+        self::assertSame('sendcloud:letter', $shipment->shipWith['type']);
     }
 }

--- a/tests/Service/ShipmentServiceTest.php
+++ b/tests/Service/ShipmentServiceTest.php
@@ -5,6 +5,7 @@ namespace Sendcloud\Bundle\Tests\Service;
 use PHPUnit\Framework\TestCase;
 use Sendcloud\Bundle\DTO\Address;
 use Sendcloud\Bundle\DTO\Shipment;
+use Sendcloud\Bundle\DTO\Parcel;
 use Sendcloud\Bundle\Exception\SendcloudApiException;
 use Sendcloud\Bundle\Service\ShipmentService;
 use Symfony\Component\Validator\ConstraintViolation;
@@ -44,7 +45,8 @@ class ShipmentServiceTest extends TestCase
             null,
             null,
         );
-        $this->shipment = new Shipment($to, $from, 1.0);
+        $parcel = new Parcel(1.0);
+        $this->shipment = new Shipment($to, $from, [$parcel]);
     }
 
     public function testAnnounceShipmentReturnsResponseArray(): void


### PR DESCRIPTION
## Summary
- Remove weight from Shipment DTO and add parcels and ship_with with default type `sendcloud:letter`
- Add Parcel DTO and update factory and entity interface for parcel and ship_with support

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_b_689df80654c4832d86c3e50b39b1f4a2