### PR TITLE
Represent parcel weight as value-unit array

### DIFF
--- a/src/DTO/Parcel.php
+++ b/src/DTO/Parcel.php
@@ -6,12 +6,21 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class Parcel
 {
-    #[Assert\Positive]
-    public float $weight;
+    /**
+     * @var array{value: float, unit: string}
+     */
+    #[Assert\Collection(fields: [
+        'value' => [new Assert\Required(), new Assert\Positive()],
+        'unit' => [new Assert\Required(), new Assert\NotBlank()],
+    ])]
+    public array $weight;
 
-    public function __construct(float $weight)
+    public function __construct(float $value, string $unit = 'kg')
     {
-        $this->weight = $weight;
+        $this->weight = [
+            'value' => $value,
+            'unit' => $unit,
+        ];
     }
 
     public function toArray(): array

--- a/tests/DTO/ShipmentTest.php
+++ b/tests/DTO/ShipmentTest.php
@@ -42,7 +42,7 @@ class ShipmentTest extends TestCase
             'to_address' => $to->toArray(),
             'from_address' => $from->toArray(),
             'parcels' => [
-                ['weight' => 1.5],
+                ['weight' => ['value' => 1.5, 'unit' => 'kg']],
             ],
             'ship_with' => ['type' => 'sendcloud:letter'],
         ];

--- a/tests/Factory/ShipmentDtoFactoryTest.php
+++ b/tests/Factory/ShipmentDtoFactoryTest.php
@@ -30,7 +30,8 @@ class ShipmentDtoFactoryTest extends TestCase
         self::assertInstanceOf(Shipment::class, $shipment);
         self::assertSame('Jane Doe', $shipment->toAddress->name);
         self::assertSame('Sender', $shipment->fromAddress->name);
-        self::assertSame(2.0, $shipment->parcels[0]->weight);
+        self::assertSame(2.0, $shipment->parcels[0]->weight['value']);
+        self::assertSame('kg', $shipment->parcels[0]->weight['unit']);
         self::assertSame('sendcloud:letter', $shipment->shipWith['type']);
     }
 }


### PR DESCRIPTION
## Summary
- model Parcel weight as value/unit pair to match Sendcloud API
- update tests for weight structure

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_b_689f0e3129b4832db71b88e16eb874e1